### PR TITLE
Convert `result|skipped` to `result is skipped`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,7 @@
       loop: "{{ download_gnome_shell_extensions.results }}"
       loop_control:
         label: "{{ item.item.item.json.name }}"
-      when: not item|skipped
+      when: not item is skipped
 
     - name: Install Gnome Shell extensions
       unarchive:
@@ -60,7 +60,7 @@
       loop: "{{ download_gnome_shell_extensions.results }}"
       loop_control:
         label: "{{ item.item.item.json.name }}"
-      when: not item|skipped
+      when: not item is skipped
 
     - name: Enable Gnome Shell extensions
       command: gnome-shell-extension-tool --enable-extension {{ item.item.item.json.uuid }}
@@ -68,7 +68,7 @@
       loop: "{{ download_gnome_shell_extensions.results }}"
       loop_control:
         label: "{{ item.item.item.json.name }}"
-      when: not item|skipped
+      when: not item is skipped
   always:
     - name: Delete temporary download directory
       file:


### PR DESCRIPTION
Ansible playbook throws the following warning when running with version
2.7.10

[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of
using `result|skipped` use `result is
skipped`. This feature will be removed in version 2.9. Deprecation
warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.

This fixes the deprecation warning. Let me know if this seems correct!