### PR TITLE
🐛 Fixes default vars defined in wrong file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for gnome-extensions
+
+gnome_extension_ids: []

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,0 @@
----
-# vars file for gnome-extensions
-
-gnome_extension_ids: []


### PR DESCRIPTION
Vars defined in `vars/main.yml` have very high precedence and so are quite hard to override when using the role (see https://docs.ansible.com/ansible/devel/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable)

Instead, I suggest to put a default value for `gnome_extension_ids` in `defaults/main.yml`