### PR TITLE
check for supported extensions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,8 +15,10 @@
     return_content: yes
   loop: "{{ gnome_extension_ids }}"
   register: r_gnome_extension_info
+  ignore_errors: yes
 
 - include_tasks: install_extension.yml
   vars:
     gnome_extension_info: "{{ item.json }}"
   loop: "{{ r_gnome_extension_info.results }}"
+  when: item.status == 200


### PR DESCRIPTION
Ignore errors when using the `uri` module for cases where the extension ID doesn't exist, or the extension does not currently support your version of `gnome-shell`. It will additionally check the status code for `200 OK` only to avoid the edge case where no provided extension IDs  are valid (failing the entire playbook).

Came across this when testing against `gnome-shell` 40 in Fedora 34 Beta.